### PR TITLE
Simplify open calls

### DIFF
--- a/filtrera_langd.py
+++ b/filtrera_langd.py
@@ -5,14 +5,14 @@ def filtrera_ord_efter_langd(indata_txt_fil, utdata_txt_fil, min_langd=2, max_la
     godkanda_ord = []
 
     # Las in ord fran indatafilen och filtrera dem
-    with open(indata_txt_fil, mode='r', encoding='utf-8') as indata_fil:
+    with open(indata_txt_fil) as indata_fil:
         for rad in indata_fil:
             ordet = rad.strip()  # Behall ursprunglig skiftlage
             if min_langd <= len(ordet) <= max_langd:
                 godkanda_ord.append(ordet)
 
     # Skriv de filtrerade orden till en ny fil
-    with open(utdata_txt_fil, mode='w', encoding='utf-8') as utdata_fil:
+    with open(utdata_txt_fil, 'w') as utdata_fil:
         for ordet in godkanda_ord:
             utdata_fil.write(ordet + '\n')
 

--- a/filtrera_namn.py
+++ b/filtrera_namn.py
@@ -7,7 +7,7 @@ def filtrera_ord_saol(saol_csv_fil, ord_txt_fil, utdata_txt_fil):
     namn_ord = set()
 
     # Las in alla ord med ordklassen 'namn'
-    with open(saol_csv_fil, mode='r', encoding='utf-8') as saol_fil:
+    with open(saol_csv_fil) as saol_fil:
         saol_reader = csv.reader(saol_fil)
         for rad in saol_reader:
             if len(rad) > 2 and rad[2].strip().lower() == 'namn':
@@ -18,14 +18,14 @@ def filtrera_ord_saol(saol_csv_fil, ord_txt_fil, utdata_txt_fil):
     filtrerade_ord = []
 
     # Filtrera ord fran den andra textfilen
-    with open(ord_txt_fil, mode='r', encoding='utf-8') as ord_fil:
+    with open(ord_txt_fil) as ord_fil:
         for rad in ord_fil:
             ordet = rad.strip().lower()
             if ordet not in namn_ord:
                 filtrerade_ord.append(rad.strip())
 
     # Skriv de filtrerade orden till en ny fil
-    with open(utdata_txt_fil, mode='w', encoding='utf-8') as utdata_fil:
+    with open(utdata_txt_fil, 'w') as utdata_fil:
         for ordet in filtrerade_ord:
             utdata_fil.write(ordet + '\n')
 

--- a/sortera_dubletter.py
+++ b/sortera_dubletter.py
@@ -5,7 +5,7 @@ def sortera_och_ta_bort_dubletter(indata_txt_fil, utdata_txt_fil):
     unika_ord = set()
 
     # Las in ord fran indatafilen
-    with open(indata_txt_fil, mode='r', encoding='utf-8') as indata_fil:
+    with open(indata_txt_fil) as indata_fil:
         for rad in indata_fil:
             ordet = rad.strip()
             if ordet:
@@ -14,7 +14,7 @@ def sortera_och_ta_bort_dubletter(indata_txt_fil, utdata_txt_fil):
     sorterade_unika_ord = sorted(unika_ord)
 
     # Skriv resultatet till en ny fil
-    with open(utdata_txt_fil, mode='w', encoding='utf-8') as utdata_fil:
+    with open(utdata_txt_fil, 'w') as utdata_fil:
         for ordet in sorterade_unika_ord:
             utdata_fil.write(ordet + '\n')
 


### PR DESCRIPTION
## Summary
- remove redundant `mode` and `encoding` from open calls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68657ce839708333bc76f3a0d6fd6082