### PR TITLE
Fix slash filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Följande ord är inte giltiga i WordFeud:
 * Ord som innehåller någon av de följande bokstäverna eller tecknen: 
     * Q eller W
     * Ê, Ñ, Ç, Ü eller Æ
-    * bindestreck (-), kolon (:), eller apostrof (‘)
+    * bindestreck (-), kolon (:), snedstreck (/), eller apostrof (‘)
     * siffror
     * mellanslag
 

--- a/wordlist_pipeline.py
+++ b/wordlist_pipeline.py
@@ -43,7 +43,7 @@ def rensa_tecken(indata_txt_fil, utdata_txt_fil):
         'É': 'E', 'È': 'E', 'À': 'A',
         'é': 'E', 'è': 'E', 'à': 'A'
     })
-    invalid_re = re.compile(r"[QWÊÑÇÜÆ\-:'0-9 ]", re.IGNORECASE)
+    invalid_re = re.compile(r"[QWÊÑÇÜÆ\-:/'0-9 ]", re.IGNORECASE)
 
     delar_att_ta_bort = set()
     godkanda_ord = []


### PR DESCRIPTION
## Summary
- document that WordFeud rejects words containing `/`
- filter `/` in the word list processing pipeline

## Testing
- `python -m py_compile wordlist_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68659b345b588333b63b5fa48cbca79c